### PR TITLE
feat: add Project & Task entities with repositories and Unit of Work

### DIFF
--- a/src/TaskTeamManagementSystem.Api/Policies/PoliciesRegister.cs
+++ b/src/TaskTeamManagementSystem.Api/Policies/PoliciesRegister.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Runtime.CompilerServices;
+using TaskTeamManagementSystem.Api.Policies.TeamLeader;
+
+namespace TaskTeamManagementSystem.Api.Policies
+{
+    public static class PoliciesRegister
+    {
+        public static IServiceCollection AddPolicies(this IServiceCollection services)
+        {
+            
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("ProjectLeaderPolicy", policy => 
+                policy.Requirements.Add(new ProjectLeaderRequirement()));
+            });
+
+
+            services.AddScoped<IAuthorizationHandler, ProjectLeaderHandler>();
+
+            return services;
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Api/Policies/TeamLeader/ProjectLeaderHandler.cs
+++ b/src/TaskTeamManagementSystem.Api/Policies/TeamLeader/ProjectLeaderHandler.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+using TaskTeamManagementSystem.Infrastructure.Persistence;
+
+namespace TaskTeamManagementSystem.Api.Policies.TeamLeader
+{
+    public class ProjectLeaderHandler : AuthorizationHandler<ProjectLeaderRequirement>
+    {
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly ApplicationDbContext dbContext;
+
+        public ProjectLeaderHandler(IHttpContextAccessor httpContextAccessor , ApplicationDbContext dbContext)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+            this.dbContext = dbContext;
+        }
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ProjectLeaderRequirement requirement)
+        {
+            var UserId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (UserId == null)
+                return Task.CompletedTask;
+
+            var routeValues = httpContextAccessor.HttpContext?.Request.RouteValues;
+
+            if(routeValues == null || !routeValues.ContainsKey("projectId"))
+                return Task.CompletedTask;
+
+            var projectId = int.Parse(routeValues["projectId"].ToString());
+
+            /*
+             var isLeader = await dbContext.Projects.AnyAsync(p => p.Id == projectId && p.TeamLeaderId == userId);
+
+            if (isLeader)
+            {
+                context.Succeed(requirement);
+            }
+            */
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Api/Policies/TeamLeader/ProjectLeaderRequirement.cs
+++ b/src/TaskTeamManagementSystem.Api/Policies/TeamLeader/ProjectLeaderRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace TaskTeamManagementSystem.Api.Policies.TeamLeader
+{
+    public class ProjectLeaderRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/src/TaskTeamManagementSystem.Api/Program.cs
+++ b/src/TaskTeamManagementSystem.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.OpenApi.Models;
 using TaskTeamManagementSystem.Api.Helper;
+using TaskTeamManagementSystem.Api.Policies;
 using TaskTeamManagementSystem.Application;
 using TaskTeamManagementSystem.Infrastructure;
 
@@ -11,6 +12,10 @@ builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 //builder.Services.AddOpenApi();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddHttpContextAccessor();
+
+builder.Services.AddPolicies();
 
 builder.Services.AddApplication().AddInfrastructure(builder.Configuration);
 

--- a/src/TaskTeamManagementSystem.Application/Class1.cs
+++ b/src/TaskTeamManagementSystem.Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace TaskTeamManagementSystem.Application;
-
-public class Class1
-{
-
-}

--- a/src/TaskTeamManagementSystem.Application/Interfaces/IUnitOfWork.cs
+++ b/src/TaskTeamManagementSystem.Application/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Application.Interfaces
+{
+    public interface IUnitOfWork : IAsyncDisposable
+    {
+        IProjectRepository Projects { get; }
+        ITaskRepository Tasks { get; }
+        Task<int> CommitChangesAsync();
+    }
+}

--- a/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/IGenericRepository.cs
+++ b/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/IGenericRepository.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Application.Interfaces.Repositories
+{
+    public interface IGenericRepository <TEntity, Tkey> where TEntity : BaseEntity<Tkey>
+    {
+        Task<IReadOnlyList<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>> predicate);
+        Task<TEntity?> GetByIdAsync(Tkey id);
+        Task AddAsync(TEntity item);
+        void Remove(TEntity item);
+        void Update(TEntity item);
+    }
+}

--- a/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/IProjectRepository.cs
+++ b/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/IProjectRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Application.Interfaces.Repositories
+{
+    public interface IProjectRepository 
+    {
+    }
+}

--- a/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/ITaskRepository.cs
+++ b/src/TaskTeamManagementSystem.Application/Interfaces/Repositories/ITaskRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Application.Interfaces.Repositories
+{
+    public interface ITaskRepository
+    {
+    }
+}

--- a/src/TaskTeamManagementSystem.Domain/Entities/BaseEntity.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TaskTeamManagementSystem.Domain.Entities
+{
+    public class BaseEntity<Tkey>
+    {
+        public Tkey Id { get; set; }
+    }
+}

--- a/src/TaskTeamManagementSystem.Domain/Entities/Identtity/AppUser.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/Identtity/AppUser.cs
@@ -11,5 +11,7 @@ namespace TaskTeamManagementSystem.Domain.Entities.Identtity
     {
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        public ICollection<ProjectTask> Tasks { get; set; }
+        public ICollection<Project> Projects { get; set; }
     }
 }

--- a/src/TaskTeamManagementSystem.Domain/Entities/Identtity/AppUser.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/Identtity/AppUser.cs
@@ -12,6 +12,7 @@ namespace TaskTeamManagementSystem.Domain.Entities.Identtity
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public ICollection<ProjectTask> Tasks { get; set; }
-        public ICollection<Project> Projects { get; set; }
+        public ICollection<Project> LeadingProjects { get; set; } = new List<Project>();
+        public ICollection<Project> ProjectMemberships { get; set; } = new List<Project>();
     }
 }

--- a/src/TaskTeamManagementSystem.Domain/Entities/Project.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/Project.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities.Identtity;
+
+namespace TaskTeamManagementSystem.Domain.Entities
+{
+    public class Project : BaseEntity<int>
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public string LeaderId { get; set; }
+        public AppUser Leader { get; set; }
+        public ICollection<ProjectTask> Tasks { get; set; }
+    }
+}

--- a/src/TaskTeamManagementSystem.Domain/Entities/Project.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/Project.cs
@@ -12,8 +12,9 @@ namespace TaskTeamManagementSystem.Domain.Entities
         public string Title { get; set; }
         public string Description { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.Now;
-        public string LeaderId { get; set; }
-        public AppUser Leader { get; set; }
+        public string? LeaderId { get; set; }
+        public AppUser? Leader { get; set; }
+        public ICollection<AppUser> Memebers { get; set; }
         public ICollection<ProjectTask> Tasks { get; set; }
     }
 }

--- a/src/TaskTeamManagementSystem.Domain/Entities/ProjectTask.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/ProjectTask.cs
@@ -15,8 +15,8 @@ namespace TaskTeamManagementSystem.Domain.Entities
         public int Status { get; set; } = 0;// 0 - NotStarted , 1 - InProgress , 2 - Done
         public int Type { get; set; } = 0; // 0 - Task , 1 - Bug , 2 - Feature 
         public int ProjId { get; set; }
-        public string AssigneeUserId { get; set; }
-        public AppUser  AssigneeUser { get; set; }
+        public string? AssigneeUserId { get; set; }
+        public AppUser?  AssigneeUser { get; set; }
         public Project Project { get; set; }
 
     }

--- a/src/TaskTeamManagementSystem.Domain/Entities/ProjectTask.cs
+++ b/src/TaskTeamManagementSystem.Domain/Entities/ProjectTask.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities.Identtity;
+
+namespace TaskTeamManagementSystem.Domain.Entities
+{
+    public class ProjectTask : BaseEntity<int>
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public int Status { get; set; } = 0;// 0 - NotStarted , 1 - InProgress , 2 - Done
+        public int Type { get; set; } = 0; // 0 - Task , 1 - Bug , 2 - Feature 
+        public int ProjId { get; set; }
+        public string AssigneeUserId { get; set; }
+        public AppUser  AssigneeUser { get; set; }
+        public Project Project { get; set; }
+
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/DependencyInjection.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/DependencyInjection.cs
@@ -1,14 +1,17 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System.Text;
-using TaskTeamManagementSystem.Domain.Entities.Identtity;
-using TaskTeamManagementSystem.Infrastructure.Persistence;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using TaskTeamManagementSystem.Application.Features.Auth.Interfaces;
+using TaskTeamManagementSystem.Application.Interfaces;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+using TaskTeamManagementSystem.Domain.Entities.Identtity;
 using TaskTeamManagementSystem.Infrastructure.Identity;
+using TaskTeamManagementSystem.Infrastructure.Persistence;
+using TaskTeamManagementSystem.Infrastructure.Persistence.Repositories;
 
 namespace TaskTeamManagementSystem.Infrastructure
 {
@@ -55,6 +58,18 @@ namespace TaskTeamManagementSystem.Infrastructure
 
             #region Jwt Generator Register
             services.AddScoped<IJwtGenerator, JwtGenerator>();
+            #endregion
+
+            #region ADD Uint of work
+                services.AddScoped<IUnitOfWork, UnitOfWork>();
+            #endregion
+
+            #region ADD Project Repo
+            services.AddScoped<IProjectRepository, ProjectRepository>();
+            #endregion
+
+            #region ADD Task Repo
+            services.AddScoped<ITaskRepository, TaskRepository>();
             #endregion
 
             return services;

--- a/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918134319_AddProjectAndTaskEntities.Designer.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918134319_AddProjectAndTaskEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TaskTeamManagementSystem.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using TaskTeamManagementSystem.Infrastructure.Persistence;
 namespace TaskTeamManagementSystem.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250918134319_AddProjectAndTaskEntities")]
+    partial class AddProjectAndTaskEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918134319_AddProjectAndTaskEntities.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918134319_AddProjectAndTaskEntities.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TaskTeamManagementSystem.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectAndTaskEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Projects",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    LeaderId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Projects", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Projects_AspNetUsers_LeaderId",
+                        column: x => x.LeaderId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Tasks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    ProjId = table.Column<int>(type: "int", nullable: false),
+                    AssigneeUserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tasks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Tasks_AspNetUsers_AssigneeUserId",
+                        column: x => x.AssigneeUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Tasks_Projects_ProjId",
+                        column: x => x.ProjId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_LeaderId",
+                table: "Projects",
+                column: "LeaderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tasks_AssigneeUserId",
+                table: "Tasks",
+                column: "AssigneeUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tasks_ProjId",
+                table: "Tasks",
+                column: "ProjId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Tasks");
+
+            migrationBuilder.DropTable(
+                name: "Projects");
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918170058_AddEntitiesWithConfigrations.Designer.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918170058_AddEntitiesWithConfigrations.Designer.cs
@@ -12,8 +12,8 @@ using TaskTeamManagementSystem.Infrastructure.Persistence;
 namespace TaskTeamManagementSystem.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250918134319_AddProjectAndTaskEntities")]
-    partial class AddProjectAndTaskEntities
+    [Migration("20250918170058_AddEntitiesWithConfigrations")]
+    partial class AddEntitiesWithConfigrations
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -247,7 +247,6 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LeaderId")
-                        .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Title")
@@ -270,7 +269,6 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AssigneeUserId")
-                        .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTime>("CreatedAt")
@@ -300,6 +298,21 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.HasIndex("ProjId");
 
                     b.ToTable("Tasks");
+                });
+
+            modelBuilder.Entity("UsersProjects", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("int");
+
+                    b.HasKey("UserId", "ProjectId");
+
+                    b.HasIndex("ProjectId");
+
+                    b.ToTable("UsersProjects");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
@@ -356,10 +369,9 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
             modelBuilder.Entity("TaskTeamManagementSystem.Domain.Entities.Project", b =>
                 {
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", "Leader")
-                        .WithMany("Projects")
+                        .WithMany("LeadingProjects")
                         .HasForeignKey("LeaderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("Leader");
                 });
@@ -369,8 +381,7 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", "AssigneeUser")
                         .WithMany("Tasks")
                         .HasForeignKey("AssigneeUserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Project", "Project")
                         .WithMany("Tasks")
@@ -383,9 +394,24 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.Navigation("Project");
                 });
 
+            modelBuilder.Entity("UsersProjects", b =>
+                {
+                    b.HasOne("TaskTeamManagementSystem.Domain.Entities.Project", null)
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", b =>
                 {
-                    b.Navigation("Projects");
+                    b.Navigation("LeadingProjects");
 
                     b.Navigation("Tasks");
                 });

--- a/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918170058_AddEntitiesWithConfigrations.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Migrations/20250918170058_AddEntitiesWithConfigrations.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace TaskTeamManagementSystem.Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class AddProjectAndTaskEntities : Migration
+    public partial class AddEntitiesWithConfigrations : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -20,7 +20,7 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    LeaderId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    LeaderId = table.Column<string>(type: "nvarchar(450)", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -30,7 +30,7 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                         column: x => x.LeaderId,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.SetNull);
                 });
 
             migrationBuilder.CreateTable(
@@ -45,7 +45,7 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     Status = table.Column<int>(type: "int", nullable: false),
                     Type = table.Column<int>(type: "int", nullable: false),
                     ProjId = table.Column<int>(type: "int", nullable: false),
-                    AssigneeUserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    AssigneeUserId = table.Column<string>(type: "nvarchar(450)", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -55,10 +55,34 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                         column: x => x.AssigneeUserId,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.SetNull);
                     table.ForeignKey(
                         name: "FK_Tasks_Projects_ProjId",
                         column: x => x.ProjId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UsersProjects",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProjectId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UsersProjects", x => new { x.UserId, x.ProjectId });
+                    table.ForeignKey(
+                        name: "FK_UsersProjects_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UsersProjects_Projects_ProjectId",
+                        column: x => x.ProjectId,
                         principalTable: "Projects",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
@@ -78,6 +102,11 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                 name: "IX_Tasks_ProjId",
                 table: "Tasks",
                 column: "ProjId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UsersProjects_ProjectId",
+                table: "UsersProjects",
+                column: "ProjectId");
         }
 
         /// <inheritdoc />
@@ -85,6 +114,9 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Tasks");
+
+            migrationBuilder.DropTable(
+                name: "UsersProjects");
 
             migrationBuilder.DropTable(
                 name: "Projects");

--- a/src/TaskTeamManagementSystem.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -244,7 +244,6 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LeaderId")
-                        .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Title")
@@ -267,7 +266,6 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AssigneeUserId")
-                        .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTime>("CreatedAt")
@@ -297,6 +295,21 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.HasIndex("ProjId");
 
                     b.ToTable("Tasks");
+                });
+
+            modelBuilder.Entity("UsersProjects", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("int");
+
+                    b.HasKey("UserId", "ProjectId");
+
+                    b.HasIndex("ProjectId");
+
+                    b.ToTable("UsersProjects");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
@@ -353,10 +366,9 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
             modelBuilder.Entity("TaskTeamManagementSystem.Domain.Entities.Project", b =>
                 {
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", "Leader")
-                        .WithMany("Projects")
+                        .WithMany("LeadingProjects")
                         .HasForeignKey("LeaderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("Leader");
                 });
@@ -366,8 +378,7 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", "AssigneeUser")
                         .WithMany("Tasks")
                         .HasForeignKey("AssigneeUserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("TaskTeamManagementSystem.Domain.Entities.Project", "Project")
                         .WithMany("Tasks")
@@ -380,9 +391,24 @@ namespace TaskTeamManagementSystem.Infrastructure.Migrations
                     b.Navigation("Project");
                 });
 
+            modelBuilder.Entity("UsersProjects", b =>
+                {
+                    b.HasOne("TaskTeamManagementSystem.Domain.Entities.Project", null)
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("TaskTeamManagementSystem.Domain.Entities.Identtity.AppUser", b =>
                 {
-                    b.Navigation("Projects");
+                    b.Navigation("LeadingProjects");
 
                     b.Navigation("Tasks");
                 });

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -3,8 +3,10 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
 using TaskTeamManagementSystem.Domain.Entities.Identtity;
 
 namespace TaskTeamManagementSystem.Infrastructure.Persistence
@@ -15,9 +17,12 @@ namespace TaskTeamManagementSystem.Infrastructure.Persistence
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
+            builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
             base.OnModelCreating(builder);
         }
-            
-        
+
+        public DbSet<ProjectTask> Tasks { get; set; }
+        public DbSet<Project> Projects { get; set; }
+
     }
 }

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/ProjectConfig.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/ProjectConfig.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Configrations
+{
+    public class ProjectConfig : IEntityTypeConfiguration<Project>
+    {
+        public void Configure(EntityTypeBuilder<Project> builder)
+        {
+            builder.HasKey(project => project.Id);
+
+            builder.HasOne(project => project.Leader)
+                   .WithMany(leader => leader.Projects)
+                   .HasForeignKey(project => project.LeaderId);
+
+            builder.HasMany(project => project.Tasks)
+                   .WithOne(task => task.Project)
+                   .HasForeignKey(task => task.ProjId);
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/ProjectConfig.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/ProjectConfig.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using TaskTeamManagementSystem.Domain.Entities;
+using TaskTeamManagementSystem.Domain.Entities.Identtity;
 
 namespace TaskTeamManagementSystem.Infrastructure.Persistence.Configrations
 {
@@ -16,12 +17,23 @@ namespace TaskTeamManagementSystem.Infrastructure.Persistence.Configrations
             builder.HasKey(project => project.Id);
 
             builder.HasOne(project => project.Leader)
-                   .WithMany(leader => leader.Projects)
-                   .HasForeignKey(project => project.LeaderId);
+                   .WithMany(leader => leader.LeadingProjects)
+                   .HasForeignKey(project => project.LeaderId)
+                   .OnDelete(DeleteBehavior.SetNull);
 
             builder.HasMany(project => project.Tasks)
                    .WithOne(task => task.Project)
-                   .HasForeignKey(task => task.ProjId);
+                   .HasForeignKey(task => task.ProjId)
+                   .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(project => project.Memebers)
+                   .WithMany(member => member.ProjectMemberships)
+                   .UsingEntity<Dictionary<string, object>>(
+                    "UsersProjects",
+                    j => j.HasOne<AppUser>().WithMany().HasForeignKey("UserId").OnDelete(DeleteBehavior.Cascade),
+                    j => j.HasOne<Project>().WithMany().HasForeignKey("ProjectId").OnDelete(DeleteBehavior.Cascade),
+                    j =>{j.HasKey("UserId", "ProjectId"); }
+                    );
         }
     }
 }

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/TaskConfig.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/TaskConfig.cs
@@ -17,11 +17,13 @@ namespace TaskTeamManagementSystem.Infrastructure.Persistence.Configrations
 
             builder.HasOne(task => task.AssigneeUser)
                    .WithMany(user => user.Tasks)
-                   .HasForeignKey(task => task.AssigneeUserId);
+                   .HasForeignKey(task => task.AssigneeUserId)
+                   .OnDelete(DeleteBehavior.SetNull);
 
             builder.HasOne(task => task.Project)
                    .WithMany(project => project.Tasks)
-                   .HasForeignKey(task => task.ProjId);
+                   .HasForeignKey(task => task.ProjId)
+                   .OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/TaskConfig.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Configrations/TaskConfig.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Configrations
+{
+    public class TaskConfig : IEntityTypeConfiguration<ProjectTask>
+    {
+        public void Configure(EntityTypeBuilder<ProjectTask> builder)
+        {
+            builder.HasKey(task => task.Id);
+
+            builder.HasOne(task => task.AssigneeUser)
+                   .WithMany(user => user.Tasks)
+                   .HasForeignKey(task => task.AssigneeUserId);
+
+            builder.HasOne(task => task.Project)
+                   .WithMany(project => project.Tasks)
+                   .HasForeignKey(task => task.ProjId);
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/GenericRepository.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/GenericRepository.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Repositories
+{
+    public class GenericRepository<TEntity, TKey> : IGenericRepository<TEntity, TKey> where TEntity : BaseEntity<TKey>
+    {
+        private readonly ApplicationDbContext dbContext;
+        private readonly DbSet<TEntity> dbSet;
+        public GenericRepository(ApplicationDbContext dbContext)
+        {
+            this.dbContext = dbContext;
+            this.dbSet = dbContext.Set<TEntity>();
+        }
+        public async Task AddAsync(TEntity item) => await dbSet.AddAsync(item);
+
+        public async Task<IReadOnlyList<TEntity>> GetAllAsync(Expression<Func<TEntity, bool>> predicate)
+        {
+            return await dbSet.Where(predicate).ToListAsync();
+        }
+
+        public async Task<TEntity?> GetByIdAsync(TKey id)
+        {
+            return await dbSet.FindAsync(id);
+        }
+
+        public void Remove(TEntity item)
+        {
+            dbSet.Remove(item);
+        }
+
+        public void Update(TEntity item)
+        {
+            dbSet.Update(item);
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/ProjectRepository.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/ProjectRepository.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Repositories
+{
+    public class ProjectRepository : GenericRepository<Project, int> , IProjectRepository
+    {
+        public ProjectRepository(ApplicationDbContext dbContext) : base(dbContext)
+        {
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/TaskRepository.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/TaskRepository.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+using TaskTeamManagementSystem.Domain.Entities;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Repositories
+{
+    public class TaskRepository : GenericRepository<ProjectTask, int> , ITaskRepository
+    {
+        public TaskRepository(ApplicationDbContext dbContext) : base(dbContext)
+        {
+        }
+    }
+}

--- a/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/UnitOfWork.cs
+++ b/src/TaskTeamManagementSystem.Infrastructure/Persistence/Repositories/UnitOfWork.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskTeamManagementSystem.Application.Interfaces;
+using TaskTeamManagementSystem.Application.Interfaces.Repositories;
+
+namespace TaskTeamManagementSystem.Infrastructure.Persistence.Repositories
+{
+    public class UnitOfWork : IUnitOfWork
+    {
+        private readonly ApplicationDbContext dbContext;
+        private readonly IServiceProvider serviceProvider;
+
+        public UnitOfWork(ApplicationDbContext dbContext , IServiceProvider serviceProvider)
+        {
+            this.dbContext = dbContext;
+            this.serviceProvider = serviceProvider;
+        }
+        public IProjectRepository Projects => serviceProvider.GetRequiredService<IProjectRepository>();
+
+        public ITaskRepository Tasks => serviceProvider.GetRequiredService<ITaskRepository>();
+
+        public async Task<int> CommitChangesAsync()
+        {
+            return await dbContext.SaveChangesAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await dbContext.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces the Project and Task entities, along with their relationships,
repositories, and the Unit of Work pattern to manage database operations.

## Changes
- Added Project and Task entities with Fluent API configuration
- Implemented Generic Repository pattern
- Added ProjectRepository and TaskRepository
- Introduced Unit of Work to coordinate repository operations
- Configured DI container for repositories and Unit of Work

## Why
To provide a clean and maintainable way to handle data access logic for projects
and tasks, ensuring consistency and separation of concerns.
